### PR TITLE
Fix setup.py dependency problem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,12 @@
 from distutils.core import setup
+from pathlib import Path
 
-from dynamotable import __version__
+version_path = Path(__file__).parent.absolute() / 'dynamotable' / 'version.py'
+with open(version_path) as f:
+    for line in f.readlines():
+        if line.startswith('__version__ ='):
+            __version__ = line
+            break
 
 setup(
     name='dynamotable',


### PR DESCRIPTION
This should fix an issue with `setup.py`, which was importing the whole package on installation (and failing if dependencies were not already installed).